### PR TITLE
config: common.mk: Remove deprecated CMAccount

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -152,7 +152,6 @@ PRODUCT_PACKAGES += \
     CMFileManager \
     LockClock \
     CMUpdater \
-    CMAccount \
     CMHome
 
 # CM Hardware Abstraction Framework


### PR DESCRIPTION
Depends on http://review.cyanogenmod.org/#/c/131177/

Change-Id: Iba0d6f58f39fa567f04bc93c96ec478f955da84d
(cherry picked from commit a0f16467f77be3359c10cb156fbfa403e973765f)
